### PR TITLE
feat: kakao 링크 조회 추가

### DIFF
--- a/src/main/java/com/roommate/roommate/application/controller/ApplicationController.java
+++ b/src/main/java/com/roommate/roommate/application/controller/ApplicationController.java
@@ -84,4 +84,14 @@ public class ApplicationController {
         ApplicationConfirmDto response = applicationService.confirmApplication(applicationId, userId);
         return SuccessResponse.onSuccess("룸메이트를 확정했습니다.", HttpStatus.OK, response);
     }
+
+    @GetMapping("/{applicationId}/chat")
+    public ResponseEntity<SuccessResponse<String>> checkKakao(
+            HttpSession session,
+            @PathVariable(value = "applicationId") Long applicationId
+    ){
+        Long userId = (Long) session.getAttribute("userId");
+        String kakaoLink = applicationService.getKakaoLink(userId, applicationId);
+        return SuccessResponse.onSuccess("상대 유저의 오픈채팅을 가져왔습니다.", HttpStatus.OK, kakaoLink);
+    }
 }


### PR DESCRIPTION
### 1. 지원 상대의 카카오 링크 조회
- 자신의 모집자일때, 상대 지원자의 카카오 링크 조회
- 자신이 지원자일때, 상대 모집자의 카카오 링크 조회

### 2. 지원 목록 조회시 지원자의 목록 조회 유저아이디 수정
- application.getUser().getId()로 지원자의 유저아이디 가져오는 부분으로 되어있던 부분을 Post를 통해 유저 아이디

### 3. 유저가 자신의 모집글에 신청 제한 수정
